### PR TITLE
Add support for Orpheus TTS running locally in LMStudio

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "orpheus-tts-local"]
+	path = orpheus-tts-local
+	url = https://github.com/stanek-michal/orpheus-tts-local.git

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project converts markdown-formatted conversations into audio podcasts with distinct voices for each speaker. It includes tools to generate conversations from web content and convert them to audio.
 
+Note: Clone this repository with `git clone --recursive` to include the orpheus-tts-local submodule.
+
 ## Setup
 
 ### Setting up a Virtual Environment (Recommended for macOS)
@@ -30,6 +32,14 @@ pip install -r requirements-dev.txt
 
 # Set your Anthropic API key (for doc2md-convo.py)
 export ANTHROPIC_API_KEY='your-api-key-here'
+
+# For Orpheus TTS support (optional)
+# 1. Install requirements
+cd orpheus-tts-local && pip install -r requirements.txt
+
+# 2. Run LM Studio with orpheus-3b-0.1-ft model (Q4_K_M quant) - model path: isaiahbjork/orpheus-3b-0.1-ft-Q4_K_M-GGUF
+#    and enable API server on http://127.0.0.1:1234
+#    Note: This model requires about 2.5GB of RAM
 ```
 
 ## Complete Workflow: Web to Audio
@@ -46,17 +56,20 @@ The project includes `doc2md-convo.py` which fetches web content or processes lo
 ### Quick Start Examples
 
 ```bash
-# Direct piping from URL to audio
+# Direct piping from URL to audio (using edge-tts)
 python3 doc2md-convo.py https://walterra.dev | python3 md-convo2mp3.py - -o walterra-dev.mp3
 
-# From local text file
-python3 doc2md-convo.py document.txt | python3 md-convo2mp3.py - -o document-podcast.mp3
+# From local text file with Orpheus TTS
+python3 doc2md-convo.py document.txt --tts-engine orpheus | python3 md-convo2mp3.py - --tts-engine orpheus -o document-podcast.mp3
 
 # From PDF file
 python3 doc2md-convo.py report.pdf | python3 md-convo2mp3.py - -o report-podcast.mp3
 
 # With custom style/personality
 python3 doc2md-convo.py document.md -s "Make it humorous with tech jokes" | python3 md-convo2mp3.py -
+
+# Using Orpheus TTS with custom voices
+python3 doc2md-convo.py article.md --tts-engine orpheus | python3 md-convo2mp3.py - --tts-engine orpheus --alex-voice leo --jordan-voice tara
 ```
 
 ### Step-by-Step Usage
@@ -81,6 +94,9 @@ python3 doc2md-convo.py document.md -s "Make it humorous with tech jokes" | pyth
 
    # With custom system prompt
    python3 doc2md-convo.py document.md -s "Make it humorous with tech jokes"
+
+   # Using Orpheus TTS (with emotional tags support)
+   python3 doc2md-convo.py document.md --tts-engine orpheus -o DOCUMENT-CONVO.md
    ```
 
 2. **Convert conversation to audio**
@@ -94,6 +110,12 @@ python3 doc2md-convo.py document.md -s "Make it humorous with tech jokes" | pyth
 
    # Interactive mode (prompts for file)
    python3 md-convo2mp3.py
+
+   # Using Orpheus TTS instead of edge-tts
+   python3 md-convo2mp3.py DOCUMENT-CONVO.md --tts-engine orpheus
+
+   # Custom voices with Orpheus TTS
+   python3 md-convo2mp3.py DOCUMENT-CONVO.md --tts-engine orpheus --alex-voice leo --jordan-voice tara
    ```
 
 ## How it works
@@ -108,8 +130,15 @@ python3 doc2md-convo.py document.md -s "Make it humorous with tech jokes" | pyth
 
 ## Voice Configuration
 
+### Edge TTS (Default)
 - **ALEX**: Male voice (Christopher in edge-tts)
 - **JORDAN**: Female voice (Jenny in edge-tts)
+
+### Orpheus TTS
+- **ALEX**: Default is 'leo' (male voice)
+- **JORDAN**: Default is 'tara' (female voice)
+- Available voices: tara, leah, jess, leo, dan, mia, zac, zoe
+- Supports emotional tags: `<giggle>`, `<laugh>`, `<chuckle>`, `<sigh>`, `<cough>`, `<sniffle>`, `<groan>`, `<yawn>`, `<gasp>`
 
 ## Output
 
@@ -119,13 +148,32 @@ The final podcast is saved as `podcast.mp3` or custom file name in the same dire
 
 - Python 3.7+
 - For `doc2md-convo.py`: Anthropic API key (set as environment variable)
-- For `md-convo2mp3.py`: Internet connection (uses Microsoft Edge's text-to-speech service)
+- For `md-convo2mp3.py` with Edge TTS: Internet connection (uses Microsoft Edge's text-to-speech service)
+- For `md-convo2mp3.py` with Orpheus TTS:
+  - LM Studio running with orpheus-3b-0.1-ft model (Q4_K_M quant) at model path: isaiahbjork/orpheus-3b-0.1-ft-Q4_K_M-GGUF
+  - API server enabled at http://127.0.0.1:1234
+  - Requirements from orpheus-tts-local/requirements.txt
+  - At least 2.5GB of RAM for the model
 
 ## Customization
 
 ### Voices
 
-You can modify the voices in `md-convo2mp3.py` by changing the voice names in the `VOICES` dictionary.
+#### Edge TTS
+You can modify the voices in `md-convo2mp3.py` by changing the voice names in the `EDGE_VOICES` dictionary.
+
+#### Orpheus TTS
+Specify custom voices using the command line arguments:
+```bash
+python3 md-convo2mp3.py conversation.md --tts-engine orpheus --alex-voice leo --jordan-voice tara
+```
+
+#### Emotional Tags (Orpheus TTS only)
+When using Orpheus TTS, you can include emotional tags in the conversation:
+```
+**ALEX:** That's <laugh> really interesting! I never thought about it that way.
+**JORDAN:** <sigh> I know, right? The implications are quite profound.
+```
 
 ### Conversation Style
 

--- a/md-convo2mp3.py
+++ b/md-convo2mp3.py
@@ -14,10 +14,24 @@ from pathlib import Path
 import edge_tts
 from pydub import AudioSegment
 
-# Voice options from edge-tts
-VOICES = {
+# Add orpheus-tts-local to path
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'orpheus-tts-local'))
+try:
+    from gguf_orpheus import generate_speech_from_api, AVAILABLE_VOICES as ORPHEUS_AVAILABLE_VOICES
+    ORPHEUS_AVAILABLE = True
+except ImportError:
+    ORPHEUS_AVAILABLE = False
+
+# Voice options for different TTS engines
+EDGE_VOICES = {
     "ALEX": "en-US-ChristopherNeural",  # Male voice
     "JORDAN": "en-US-JennyNeural",  # Female voice
+}
+
+# Default Orpheus voices
+ORPHEUS_VOICES = {
+    "ALEX": "leo",  # Male voice
+    "JORDAN": "tara",  # Female voice
 }
 
 
@@ -46,14 +60,73 @@ def parse_conversation(input_source):
     return conversation
 
 
-async def generate_speech(text, voice, output_file):
-    """Generate speech for a single line"""
+async def generate_speech_edge(text, voice, output_file):
+    """Generate speech using edge-tts"""
     communicate = edge_tts.Communicate(text, voice, rate="+25%")
     await communicate.save(output_file)
 
 
-async def create_podcast(conversation, output_file="podcast.mp3"):
+async def generate_speech_orpheus(text, voice, output_file):
+    """Generate speech using orpheus-tts-local"""
+    if not ORPHEUS_AVAILABLE:
+        print("Error: orpheus-tts-local is not available.")
+        print("Make sure to install its requirements: cd orpheus-tts-local && pip install -r requirements.txt")
+        sys.exit(1)
+
+    try:
+        # Generate audio segments
+        print(f"Generating audio using Orpheus TTS with voice '{voice}'")
+        segments = generate_speech_from_api(text, voice=voice)
+
+        # Convert to AudioSegment and export as MP3
+        audio_data = b''.join(segments)
+        import io
+        import numpy as np
+        # Convert bytes to int16 numpy array
+        audio_np = np.frombuffer(audio_data, dtype=np.int16)
+        # Convert to AudioSegment
+        audio_segment = AudioSegment(
+            audio_np.tobytes(),
+            frame_rate=24000,  # Orpheus sample rate
+            sample_width=2,    # 16-bit audio
+            channels=1         # Mono
+        )
+        # Export as MP3
+        audio_segment.export(output_file, format="mp3")
+    except Exception as e:
+        print(f"Error generating speech with Orpheus: {e}")
+        print("Make sure LM Studio API server is running at http://127.0.0.1:1234")
+        sys.exit(1)
+
+
+async def generate_speech(text, voice, output_file, tts_engine="edge"):
+    """Generate speech for a single line"""
+    if tts_engine == "orpheus":
+        await generate_speech_orpheus(text, voice, output_file)
+    else:
+        await generate_speech_edge(text, voice, output_file)
+
+
+async def create_podcast(conversation, output_file="podcast.mp3", tts_engine="edge", alex_voice=None, jordan_voice=None):
     """Create podcast with multiple voices"""
+    # Determine which voices to use based on TTS engine
+    if tts_engine == "orpheus":
+        if not ORPHEUS_AVAILABLE:
+            print("Error: orpheus-tts-local is not available.")
+            print("Make sure to install its requirements: cd orpheus-tts-local && pip install -r requirements.txt")
+            sys.exit(1)
+
+        voices = ORPHEUS_VOICES.copy()
+        # Override with custom voices if provided
+        if alex_voice and alex_voice in ORPHEUS_AVAILABLE_VOICES:
+            voices["ALEX"] = alex_voice
+        if jordan_voice and jordan_voice in ORPHEUS_AVAILABLE_VOICES:
+            voices["JORDAN"] = jordan_voice
+
+        print(f"Using Orpheus TTS with voices: ALEX={voices['ALEX']}, JORDAN={voices['JORDAN']}")
+    else:
+        voices = EDGE_VOICES
+
     # Use secure temporary directory that gets auto-cleaned
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_path = Path(temp_dir)
@@ -63,11 +136,11 @@ async def create_podcast(conversation, output_file="podcast.mp3"):
         for i, (speaker, text) in enumerate(conversation):
             print(f"Generating audio for {speaker}: {text[:50]}...")
 
-            voice = VOICES.get(speaker, VOICES["ALEX"])
+            voice = voices.get(speaker, voices["ALEX"])
             temp_file = temp_path / f"temp_{i}.mp3"
             temp_files.append(temp_file)
 
-            await generate_speech(text, voice, str(temp_file))
+            await generate_speech(text, voice, str(temp_file), tts_engine)
 
         # Combine audio files
         print("Combining audio files...")
@@ -75,8 +148,8 @@ async def create_podcast(conversation, output_file="podcast.mp3"):
 
         for temp_file in temp_files:
             audio = AudioSegment.from_mp3(str(temp_file))
-            # Add small pause between lines
-            combined += audio  # + AudioSegment.silent(duration=1)
+            # Add small pause between lines (300ms)
+            combined += audio + AudioSegment.silent(duration=300)
 
         # Export final audio
         combined.export(output_file, format="mp3")
@@ -142,6 +215,20 @@ async def main():
         "-o",
         help='Output MP3 filename (default: based on input filename or "podcast.mp3" for stdin)',
     )
+    parser.add_argument(
+        "--tts-engine",
+        choices=["edge", "orpheus"],
+        default="edge",
+        help="TTS engine to use (default: edge)",
+    )
+    parser.add_argument(
+        "--alex-voice",
+        help="Voice for ALEX (orpheus: tara, leah, jess, leo, dan, mia, zac, zoe)",
+    )
+    parser.add_argument(
+        "--jordan-voice",
+        help="Voice for JORDAN (orpheus: tara, leah, jess, leo, dan, mia, zac, zoe)",
+    )
 
     args = parser.parse_args()
 
@@ -176,7 +263,13 @@ async def main():
         output_file = get_output_filename(input_file)
 
     print(f"Found {len(conversation)} lines of dialogue")
-    await create_podcast(conversation, output_file)
+    await create_podcast(
+        conversation,
+        output_file,
+        tts_engine=args.tts_engine,
+        alex_voice=args.alex_voice,
+        jordan_voice=args.jordan_voice
+    )
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,9 @@ PyPDF2>=3.0.0
 # Markdown parsing (legacy dependency)
 markdown==3.5.1
 
+# Dependencies for orpheus-tts integration (optional)
+# Install with: cd orpheus-tts-local && pip install -r requirements.txt
+# Note: Requires running LM Studio with API server enabled at http://127.0.0.1:1234
+
 # Development dependencies (optional)
 # Install with: pip install -r requirements-dev.txt


### PR DESCRIPTION
Key changes:
- Add orpheus-tts-local as git submodule
- Modify md-convo2mp3.py to support both Edge TTS and Orpheus TTS engines
- Add command-line arguments for TTS engine selection and voice customization
- Update doc2md-convo.py to support emotional tags for Orpheus TTS
- Update requirements.txt and README.md with Orpheus TTS documentation

Orpheus TTS supports emotional tags (<laugh>, <giggle>, etc.) and provides a completely local TTS option that doesn't depend on cloud services. It also sounds much better than Edge TTS!

To use Orpheus TTS:
1. Run LM Studio with orpheus-3b-0.1-ft model (Q4_K_M quant)
 - Model path: isaiahbjork/orpheus-3b-0.1-ft-Q4_K_M-GGUF
 - Requires approximately 2.5GB RAM
2. Enable API server at http://127.0.0.1:1234
3. Use --tts-engine orpheus flag with both tools
4. Optionally customize voices with --alex-voice and --jordan-voice

Part of #15 